### PR TITLE
Handle error when sending transaction to insight

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -113,7 +114,8 @@ func (i *InsightClient) doRequest(endpoint, method string, body io.Reader, query
 		}
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status not ok: %s", resp.Status)
+		respBody, _ := ioutil.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status not ok: %s, body: %s", resp.Status, string(respBody))
 	}
 	return resp, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -97,7 +97,7 @@ func (i *InsightClient) doRequest(endpoint, method string, body io.Reader, query
 		req.URL.RawQuery = query.Encode()
 	}
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %s\n", err)
+		return nil, fmt.Errorf("creating request: %s", err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 
@@ -113,7 +113,7 @@ func (i *InsightClient) doRequest(endpoint, method string, body io.Reader, query
 		}
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("status not ok: %s\n", resp.Status)
+		return nil, fmt.Errorf("status not ok: %s", resp.Status)
 	}
 	return resp, nil
 }
@@ -131,7 +131,7 @@ func (i *InsightClient) GetInfo() (*Info, error) {
 	stat := new(Status)
 	defer resp.Body.Close()
 	if err = decoder.Decode(stat); err != nil {
-		return nil, fmt.Errorf("error decoding status: %s\n", err)
+		return nil, fmt.Errorf("error decoding status: %s", err)
 	}
 	info := stat.Info
 	f, err := toFloat(stat.Info.RelayFeeIface)
@@ -156,7 +156,7 @@ func (i *InsightClient) GetTransaction(txid string) (*Transaction, error) {
 	decoder := json.NewDecoder(resp.Body)
 	defer resp.Body.Close()
 	if err = decoder.Decode(tx); err != nil {
-		return nil, fmt.Errorf("error decoding transactions: %s\n", err)
+		return nil, fmt.Errorf("error decoding transactions: %s", err)
 	}
 	for n, in := range tx.Inputs {
 		f, err := toFloat(in.ValueIface)
@@ -183,7 +183,7 @@ func (i *InsightClient) GetRawTransaction(txid string) ([]byte, error) {
 	defer resp.Body.Close()
 	tx := new(RawTxResponse)
 	if err = json.NewDecoder(resp.Body).Decode(tx); err != nil {
-		return nil, fmt.Errorf("error decoding transactions: %s\n", err)
+		return nil, fmt.Errorf("error decoding transactions: %s", err)
 	}
 	return hex.DecodeString(tx.RawTx)
 }
@@ -235,7 +235,7 @@ func (i *InsightClient) getTransactions(addrs []btcutil.Address, from, to int) (
 	decoder := json.NewDecoder(resp.Body)
 	defer resp.Body.Close()
 	if err = decoder.Decode(tl); err != nil {
-		return nil, fmt.Errorf("error decoding transaction list: %s\n", err)
+		return nil, fmt.Errorf("error decoding transaction list: %s", err)
 	}
 	for z, tx := range tl.Items {
 		for n, in := range tx.Inputs {
@@ -282,7 +282,7 @@ func (i *InsightClient) GetUtxos(addrs []btcutil.Address) ([]Utxo, error) {
 	decoder := json.NewDecoder(resp.Body)
 	defer resp.Body.Close()
 	if err = decoder.Decode(&utxos); err != nil {
-		return nil, fmt.Errorf("error decoding utxo list: %s\n", err)
+		return nil, fmt.Errorf("error decoding utxo list: %s", err)
 	}
 	for z, u := range utxos {
 		f, err := toFloat(u.AmountIface)
@@ -353,11 +353,11 @@ func (i *InsightClient) Broadcast(tx []byte) (string, error) {
 	t := RawTx{txHex}
 	txJson, err := json.Marshal(&t)
 	if err != nil {
-		return "", fmt.Errorf("error encoding tx: %s\n", err)
+		return "", fmt.Errorf("error encoding tx: %s", err)
 	}
 	resp, err := i.doRequest("tx/send", http.MethodPost, bytes.NewBuffer(txJson), nil)
 	if err != nil {
-		return "", fmt.Errorf("error broadcasting tx: %s\n", err)
+		return "", fmt.Errorf("error broadcasting tx: %s", err)
 	}
 	defer resp.Body.Close()
 
@@ -369,7 +369,7 @@ func (i *InsightClient) Broadcast(tx []byte) (string, error) {
 	}
 	rs := new(Response)
 	if err = json.NewDecoder(resp.Body).Decode(rs); err != nil {
-		return "", fmt.Errorf("error decoding txid: %s\n", err)
+		return "", fmt.Errorf("error decoding txid: %s", err)
 	}
 	return rs.Txid.Result, nil
 }
@@ -387,7 +387,7 @@ func (i *InsightClient) GetBestBlock() (*Block, error) {
 	sl := new(BlockList)
 	defer resp.Body.Close()
 	if err = decoder.Decode(sl); err != nil {
-		return nil, fmt.Errorf("error decoding block list: %s\n", err)
+		return nil, fmt.Errorf("error decoding block list: %s", err)
 	}
 	if len(sl.Blocks) != 2 {
 		return nil, fmt.Errorf("API returned incorrect number of block summaries")
@@ -410,7 +410,7 @@ func (i *InsightClient) GetBlocksBefore(to time.Time, limit int) (*BlockList, er
 	decoder := json.NewDecoder(resp.Body)
 	defer resp.Body.Close()
 	if err = decoder.Decode(list); err != nil {
-		return nil, fmt.Errorf("error decoding block list: %s\n", err)
+		return nil, fmt.Errorf("error decoding block list: %s", err)
 	}
 	return list, nil
 }
@@ -425,7 +425,7 @@ func toFloat(i interface{}) (float64, error) {
 		s := i.(string)
 		f, err := strconv.ParseFloat(s, 64)
 		if err != nil {
-			return 0, fmt.Errorf("error parsing value float: %s\n", err)
+			return 0, fmt.Errorf("error parsing value float: %s", err)
 		}
 		return f, nil
 	} else {
@@ -441,7 +441,7 @@ func (i *InsightClient) EstimateFee(nbBlocks int) (int, error) {
 	data := map[int]float64{}
 	defer resp.Body.Close()
 	if err = json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return 0, fmt.Errorf("error decoding fee estimate: %s\n", err)
+		return 0, fmt.Errorf("error decoding fee estimate: %s", err)
 	}
 	return int(data[nbBlocks] * 1e8), nil
 }

--- a/service/wallet_service.go
+++ b/service/wallet_service.go
@@ -369,7 +369,7 @@ func (ws *WalletService) saveSingleTxToDB(u client.Transaction, chainHeight int3
 		return
 	}
 	var relevant bool
-	cb := wallet.TransactionCallback{Txid: txHash.CloneBytes(), Height: height}
+	cb := wallet.TransactionCallback{Txid: txHash.String(), Height: height}
 	for _, in := range u.Inputs {
 		ch, err := chainhash.NewHashFromStr(in.Txid)
 		if err != nil {


### PR DESCRIPTION
Previously if `tx/send` returned an error this would panic.