### PR TITLE
[WIP] Enable InsightClient to connect to custom ports

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -6,13 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"path"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/OpenBazaar/golang-socketio"
@@ -22,7 +22,6 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/op/go-logging"
 	"golang.org/x/net/proxy"
-	"sync"
 )
 
 var Log = logging.MustGetLogger("client")
@@ -43,17 +42,11 @@ func NewInsightClient(apiUrl string, proxyDialer proxy.Dialer) (*InsightClient, 
 	if err != nil {
 		return nil, err
 	}
-	var port int
-	var secure bool
-	if u.Scheme == "https" {
-		port = 443
-		secure = true
-	} else if u.Scheme == "http" {
-		port = 80
-		secure = false
-	} else {
-		return nil, errors.New("Unknown url scheme")
+
+	if err := validateScheme(u); err != nil {
+		return nil, err
 	}
+
 	dial := net.Dial
 	if proxyDialer != nil {
 		dial = proxyDialer.Dial
@@ -69,7 +62,7 @@ func NewInsightClient(apiUrl string, proxyDialer proxy.Dialer) (*InsightClient, 
 		txNotifyChan:    tch,
 		listenLock:      sync.Mutex{},
 	}
-	go ic.setupListeners(*u, port, secure, proxyDialer)
+	go ic.setupListeners(*u, proxyDialer)
 	return ic, nil
 }
 
@@ -77,6 +70,14 @@ func (i *InsightClient) Close() {
 	if i.socketClient != nil {
 		i.socketClient.Close()
 	}
+}
+
+func validateScheme(target *url.URL) error {
+	switch target.Scheme {
+	case "https", "http":
+		return nil
+	}
+	return fmt.Errorf("unsupported scheme: %s", target.Scheme)
 }
 
 func (i *InsightClient) doRequest(endpoint, method string, body []byte, query url.Values) (*http.Response, error) {
@@ -308,14 +309,35 @@ func (i *InsightClient) ListenAddress(addr btcutil.Address) {
 	}
 }
 
-func (i *InsightClient) setupListeners(u url.URL, port int, secure bool, proxyDialer proxy.Dialer) {
+func (i *InsightClient) setupListeners(u url.URL, proxyDialer proxy.Dialer) {
+	var (
+		port   int
+		secure = u.Scheme == "https"
+	)
+
+	if parsedPort, err := strconv.ParseInt(u.Port(), 10, 32); err != nil {
+		if err != strconv.ErrSyntax {
+			Log.Errorf("parsing port: %s", err.Error())
+		}
+	} else {
+		port = int(parsedPort)
+	}
+
+	if port == 0 {
+		if secure {
+			port = 443
+		} else {
+			port = 80
+		}
+	}
+
 	for {
 		if i.socketClient != nil {
 			i.listenLock.Lock()
 			break
 		}
 		socketClient, err := gosocketio.Dial(
-			gosocketio.GetUrl(u.Host, port, secure),
+			gosocketio.GetUrl(u.Hostname(), port, secure),
 			transport.GetDefaultWebsocketTransport(proxyDialer),
 		)
 		if err == nil {


### PR DESCRIPTION
This allows the host:port format to be parsed and used properly by the InsightClient abstraction.