### PR TITLE
Replace file path injection with Cacher interface; cleanup tests

### DIFF
--- a/bitcoin/sign_test.go
+++ b/bitcoin/sign_test.go
@@ -3,6 +3,10 @@ package bitcoin
 import (
 	"bytes"
 	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/datastore"
 	"github.com/OpenBazaar/multiwallet/keys"
@@ -15,8 +19,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/hdkeychain"
-	"testing"
-	"time"
 )
 
 type FeeResponse struct {
@@ -57,7 +59,11 @@ func newMockWallet() (*BitcoinWallet, error) {
 		fp:     fp,
 	}
 	cli := client.NewMockApiClient(bw.AddressToScript)
-	ws := service.NewWalletService(db, km, cli, params, wallet.Bitcoin)
+	ws, err := service.NewWalletService(db, km, cli, params, wallet.Bitcoin, cache.NewMockCacher())
+	if err != nil {
+		return nil, err
+	}
+
 	bw.client = cli
 	bw.ws = ws
 	return bw, nil

--- a/bitcoin/wallet.go
+++ b/bitcoin/wallet.go
@@ -2,11 +2,18 @@ package bitcoin
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 	"time"
 
+	"github.com/OpenBazaar/multiwallet/cache"
+	"github.com/OpenBazaar/multiwallet/client"
+	"github.com/OpenBazaar/multiwallet/config"
+	"github.com/OpenBazaar/multiwallet/keys"
+	"github.com/OpenBazaar/multiwallet/service"
+	"github.com/OpenBazaar/multiwallet/util"
 	"github.com/OpenBazaar/spvwallet"
 	wi "github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -18,13 +25,6 @@ import (
 	"github.com/btcsuite/btcwallet/wallet/txrules"
 	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/net/proxy"
-
-	"encoding/hex"
-	"github.com/OpenBazaar/multiwallet/client"
-	"github.com/OpenBazaar/multiwallet/config"
-	"github.com/OpenBazaar/multiwallet/keys"
-	"github.com/OpenBazaar/multiwallet/service"
-	"github.com/OpenBazaar/multiwallet/util"
 )
 
 type BitcoinWallet struct {
@@ -39,7 +39,7 @@ type BitcoinWallet struct {
 	mPubKey  *hd.ExtendedKey
 }
 
-func NewBitcoinWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.Params, proxy proxy.Dialer, repoPath string) (*BitcoinWallet, error) {
+func NewBitcoinWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.Params, proxy proxy.Dialer, cache cache.Cacher) (*BitcoinWallet, error) {
 	seed := bip39.NewSeed(mnemonic, "")
 
 	mPrivKey, err := hd.NewMaster(seed, params)
@@ -60,7 +60,7 @@ func NewBitcoinWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.P
 		return nil, err
 	}
 
-	wm, err := service.NewWalletService(cfg.DB, km, c, params, wi.Bitcoin, repoPath)
+	wm, err := service.NewWalletService(cfg.DB, km, c, params, wi.Bitcoin, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/bitcoincash/sign_test.go
+++ b/bitcoincash/sign_test.go
@@ -3,6 +3,11 @@ package bitcoincash
 import (
 	"bytes"
 	"encoding/hex"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/datastore"
 	"github.com/OpenBazaar/multiwallet/keys"
@@ -15,9 +20,6 @@ import (
 	"github.com/btcsuite/btcutil/hdkeychain"
 	bcw "github.com/cpacia/BitcoinCash-Wallet"
 	"github.com/cpacia/bchutil"
-	"os"
-	"testing"
-	"time"
 )
 
 type FeeResponse struct {
@@ -57,7 +59,10 @@ func newMockWallet() (*BitcoinCashWallet, error) {
 		fp:     fp,
 	}
 	cli := client.NewMockApiClient(bw.AddressToScript)
-	ws := service.NewWalletService(db, km, cli, params, wallet.BitcoinCash)
+	ws, err := service.NewWalletService(db, km, cli, params, wallet.BitcoinCash, cache.NewMockCacher())
+	if err != nil {
+		return nil, err
+	}
 	bw.client = cli
 	bw.ws = ws
 	return bw, nil

--- a/bitcoincash/wallet.go
+++ b/bitcoincash/wallet.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/OpenBazaar/multiwallet/cache"
 	wi "github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -39,7 +40,7 @@ type BitcoinCashWallet struct {
 	mPubKey  *hd.ExtendedKey
 }
 
-func NewBitcoinCashWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.Params, proxy proxy.Dialer, repoPath string) (*BitcoinCashWallet, error) {
+func NewBitcoinCashWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.Params, proxy proxy.Dialer, cache cache.Cacher) (*BitcoinCashWallet, error) {
 	seed := bip39.NewSeed(mnemonic, "")
 
 	mPrivKey, err := hd.NewMaster(seed, params)
@@ -60,7 +61,7 @@ func NewBitcoinCashWallet(cfg config.CoinConfig, mnemonic string, params *chainc
 		return nil, err
 	}
 
-	wm, err := service.NewWalletService(cfg.DB, km, c, params, wi.BitcoinCash, repoPath)
+	wm, err := service.NewWalletService(cfg.DB, km, c, params, wi.BitcoinCash, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/cache/cacher.go
+++ b/cache/cacher.go
@@ -1,0 +1,31 @@
+package cache
+
+import "fmt"
+
+type Cacher interface {
+	Set(string, []byte) error
+	Get(string) ([]byte, error)
+}
+
+func NewMockCacher() Cacher {
+	return exampleWithNoPersistence{
+		kv: make(map[string][]byte),
+	}
+}
+
+type exampleWithNoPersistence struct {
+	kv map[string][]byte
+}
+
+func (e exampleWithNoPersistence) Set(key string, value []byte) error {
+	e.kv[key] = value
+	return nil
+}
+
+func (e exampleWithNoPersistence) Get(key string) ([]byte, error) {
+	value, ok := e.kv[key]
+	if !ok {
+		return nil, fmt.Errorf("cached key not found")
+	}
+	return value, nil
+}

--- a/cache/cacher_example_test.go
+++ b/cache/cacher_example_test.go
@@ -1,0 +1,56 @@
+package cache_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/OpenBazaar/multiwallet/cache"
+)
+
+type testStructSubject struct {
+	StringType string
+	IntType    int
+	TimeType   time.Time
+}
+
+func TestSettingGettingStructs(t *testing.T) {
+	var (
+		subject = testStructSubject{
+			StringType: "teststring",
+			IntType:    123456,
+			TimeType:   time.Now(),
+		}
+		cacher = cache.NewMockCacher()
+	)
+	marshalledSubject, err := json.Marshal(subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cacher.Set("thing1", marshalledSubject)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	marshalledThing, err := cacher.Get("thing1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var actual testStructSubject
+	err = json.Unmarshal(marshalledThing, &actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if subject.StringType != actual.StringType {
+		t.Error("expected StringType to match but did not")
+	}
+	if subject.IntType != actual.IntType {
+		t.Error("expected IntType to match but did not")
+	}
+	if !subject.TimeType.Equal(actual.TimeType) {
+		t.Error("expected TimeType to match but did not")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/datastore"
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -28,8 +29,9 @@ type Config struct {
 	// A logger. You can write the logs to file or stdout or however else you want.
 	Logger logging.Backend
 
-	// A directory where wallet metadata (such as last known height) should be stored
-	RepoPath string
+	// Cache is a persistable storage provided by the consumer where the wallet can
+	// keep state between runtime executions
+	Cache cache.Cacher
 
 	// A list of coin configs. One config should be included for each coin to be used.
 	Coins []CoinConfig
@@ -65,9 +67,9 @@ type CoinConfig struct {
 
 func NewDefaultConfig(coinTypes map[wallet.CoinType]bool, params *chaincfg.Params) *Config {
 	cfg := &Config{
-		RepoPath: "~/.multiwallet",
-		Params:   params,
-		Logger:   logging.NewLogBackend(os.Stdout, "", 0),
+		Cache:  cache.NewMockCacher(),
+		Params: params,
+		Logger: logging.NewLogBackend(os.Stdout, "", 0),
 	}
 	var testnet bool
 	if params.Name == chaincfg.TestNet3Params.Name {

--- a/litecoin/sign_test.go
+++ b/litecoin/sign_test.go
@@ -3,6 +3,10 @@ package litecoin
 import (
 	"bytes"
 	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/datastore"
 	"github.com/OpenBazaar/multiwallet/keys"
@@ -16,8 +20,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/hdkeychain"
-	"testing"
-	"time"
 )
 
 type FeeResponse struct {
@@ -58,7 +60,10 @@ func newMockWallet() (*LitecoinWallet, error) {
 		fp:     fp,
 	}
 	cli := client.NewMockApiClient(bw.AddressToScript)
-	ws := service.NewWalletService(db, km, cli, params, wallet.Litecoin)
+	ws, err := service.NewWalletService(db, km, cli, params, wallet.Litecoin, cache.NewMockCacher())
+	if err != nil {
+		return nil, err
+	}
 	bw.client = cli
 	bw.ws = ws
 	return bw, nil

--- a/litecoin/wallet.go
+++ b/litecoin/wallet.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/net/proxy"
 
 	"encoding/hex"
+	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/config"
 	"github.com/OpenBazaar/multiwallet/keys"
@@ -38,7 +39,7 @@ type LitecoinWallet struct {
 	mPubKey  *hd.ExtendedKey
 }
 
-func NewLitecoinWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.Params, proxy proxy.Dialer, repoPath string) (*LitecoinWallet, error) {
+func NewLitecoinWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.Params, proxy proxy.Dialer, cache cache.Cacher) (*LitecoinWallet, error) {
 	seed := bip39.NewSeed(mnemonic, "")
 
 	mPrivKey, err := hd.NewMaster(seed, params)
@@ -59,7 +60,7 @@ func NewLitecoinWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.
 		return nil, err
 	}
 
-	wm, err := service.NewWalletService(cfg.DB, km, c, params, wi.Litecoin, repoPath)
+	wm, err := service.NewWalletService(cfg.DB, km, c, params, wi.Litecoin, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/multiwallet.go
+++ b/multiwallet.go
@@ -48,7 +48,7 @@ func NewMultiWallet(cfg *config.Config) (MultiWallet, error) {
 		var w wallet.Wallet
 		switch coin.CoinType {
 		case wallet.Bitcoin:
-			w, err = bitcoin.NewBitcoinWallet(coin, cfg.Mnemonic, cfg.Params, cfg.Proxy, cfg.RepoPath)
+			w, err = bitcoin.NewBitcoinWallet(coin, cfg.Mnemonic, cfg.Params, cfg.Proxy, cfg.Cache)
 			if err != nil {
 				return nil, err
 			}
@@ -58,7 +58,7 @@ func NewMultiWallet(cfg *config.Config) (MultiWallet, error) {
 				multiwallet[wallet.TestnetBitcoin] = w
 			}
 		case wallet.BitcoinCash:
-			w, err = bitcoincash.NewBitcoinCashWallet(coin, cfg.Mnemonic, cfg.Params, cfg.Proxy, cfg.RepoPath)
+			w, err = bitcoincash.NewBitcoinCashWallet(coin, cfg.Mnemonic, cfg.Params, cfg.Proxy, cfg.Cache)
 			if err != nil {
 				return nil, err
 			}
@@ -68,7 +68,7 @@ func NewMultiWallet(cfg *config.Config) (MultiWallet, error) {
 				multiwallet[wallet.TestnetBitcoinCash] = w
 			}
 		case wallet.Zcash:
-			w, err = zcash.NewZCashWallet(coin, cfg.Mnemonic, cfg.Params, cfg.Proxy, cfg.RepoPath)
+			w, err = zcash.NewZCashWallet(coin, cfg.Mnemonic, cfg.Params, cfg.Proxy, cfg.Cache)
 			if err != nil {
 				return nil, err
 			}
@@ -78,7 +78,7 @@ func NewMultiWallet(cfg *config.Config) (MultiWallet, error) {
 				multiwallet[wallet.TestnetZcash] = w
 			}
 		case wallet.Litecoin:
-			w, err = litecoin.NewLitecoinWallet(coin, cfg.Mnemonic, cfg.Params, cfg.Proxy, cfg.RepoPath)
+			w, err = litecoin.NewLitecoinWallet(coin, cfg.Mnemonic, cfg.Params, cfg.Proxy, cfg.Cache)
 			if err != nil {
 				return nil, err
 			}

--- a/service/wallet_service.go
+++ b/service/wallet_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -17,14 +18,12 @@ import (
 	"github.com/op/go-logging"
 
 	"encoding/json"
+	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/keys"
 	laddr "github.com/OpenBazaar/multiwallet/litecoin/address"
 	"github.com/OpenBazaar/multiwallet/util"
 	zaddr "github.com/OpenBazaar/multiwallet/zcash/address"
-	"io/ioutil"
-	"os"
-	"path"
 )
 
 var Log = logging.MustGetLogger("WalletService")
@@ -38,7 +37,7 @@ type WalletService struct {
 
 	chainHeight uint32
 	bestBlock   string
-	repoPath    string
+	cache       cache.Cacher
 
 	listeners []func(wallet.TransactionCallback)
 
@@ -55,20 +54,37 @@ type HashAndHeight struct {
 
 const nullHash = "0000000000000000000000000000000000000000000000000000000000000000"
 
-func NewWalletService(db wallet.Datastore, km *keys.KeyManager, client client.APIClient, params *chaincfg.Params, coinType wallet.CoinType, repoPath string) (*WalletService, error) {
-	f, err := ioutil.ReadFile(path.Join(repoPath, coinType.String()+".json"))
-	best := nullHash
-	height := uint32(0)
-	if err == nil {
-		var hh HashAndHeight
-		err := json.Unmarshal(f, &hh)
-		if err != nil {
-			return nil, err
+func NewWalletService(db wallet.Datastore, km *keys.KeyManager, client client.APIClient, params *chaincfg.Params, coinType wallet.CoinType, cache cache.Cacher) (*WalletService, error) {
+	var (
+		ws = &WalletService{
+			db:          db,
+			km:          km,
+			client:      client,
+			params:      params,
+			coinType:    coinType,
+			chainHeight: 0,
+			bestBlock:   nullHash,
+
+			cache:     cache,
+			listeners: []func(wallet.TransactionCallback){},
+			lock:      sync.RWMutex{},
+			doneChan:  make(chan struct{}),
 		}
-		best = hh.Hash
-		height = hh.Height
+		marshaledHeight, err = cache.Get(ws.bestHeightKey())
+	)
+
+	if err != nil {
+		Log.Info("cached block height missing: using default")
+	} else {
+		var hh HashAndHeight
+		if err := json.Unmarshal(marshaledHeight, &hh); err != nil {
+			Log.Error("failed unmarshaling cached block height")
+			return ws, nil
+		}
+		ws.bestBlock = hh.Hash
+		ws.chainHeight = hh.Height
 	}
-	return &WalletService{db, km, client, params, coinType, height, best, repoPath, []func(wallet.TransactionCallback){}, sync.RWMutex{}, make(chan struct{})}, nil
+	return ws, nil
 }
 
 func (ws *WalletService) Start() {
@@ -562,5 +578,9 @@ func (ws *WalletService) saveHashAndHeight(hash string, height uint32) error {
 	}
 	ws.chainHeight = height
 	ws.bestBlock = hash
-	return ioutil.WriteFile(path.Join(ws.repoPath, ws.coinType.String()+".json"), b, os.ModePerm)
+	return ws.cache.Set(ws.bestHeightKey(), b)
+}
+
+func (ws *WalletService) bestHeightKey() string {
+	return fmt.Sprintf("best-height-%s", ws.coinType.String())
 }

--- a/service/wallet_service_test.go
+++ b/service/wallet_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/datastore"
 	"github.com/OpenBazaar/multiwallet/keys"
@@ -41,7 +42,7 @@ func mockWalletService() (*WalletService, error) {
 	cli := client.NewMockApiClient(func(addr btcutil.Address) ([]byte, error) {
 		return txscript.PayToAddrScript(addr)
 	})
-	return NewWalletService(db, km, cli, params, wallet.Bitcoin), nil
+	return NewWalletService(db, km, cli, params, wallet.Bitcoin, cache.NewMockCacher())
 }
 
 func bitcoinAddress(key *hdkeychain.ExtendedKey, params *chaincfg.Params) (btcutil.Address, error) {

--- a/zcash/sign_test.go
+++ b/zcash/sign_test.go
@@ -3,6 +3,11 @@ package zcash
 import (
 	"bytes"
 	"encoding/hex"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/datastore"
 	"github.com/OpenBazaar/multiwallet/keys"
@@ -16,9 +21,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/hdkeychain"
-	"os"
-	"testing"
-	"time"
 )
 
 type FeeResponse struct {
@@ -58,7 +60,10 @@ func newMockWallet() (*ZCashWallet, error) {
 		fp:     fp,
 	}
 	cli := client.NewMockApiClient(bw.AddressToScript)
-	ws := service.NewWalletService(db, km, cli, params, wallet.BitcoinCash)
+	ws, err := service.NewWalletService(db, km, cli, params, wallet.BitcoinCash, cache.NewMockCacher())
+	if err != nil {
+		return nil, err
+	}
 	bw.client = cli
 	bw.ws = ws
 	return bw, nil

--- a/zcash/wallet.go
+++ b/zcash/wallet.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/net/proxy"
 
 	"encoding/hex"
+	"github.com/OpenBazaar/multiwallet/cache"
 	"github.com/OpenBazaar/multiwallet/client"
 	"github.com/OpenBazaar/multiwallet/config"
 	"github.com/OpenBazaar/multiwallet/keys"
@@ -37,7 +38,7 @@ type ZCashWallet struct {
 	mPubKey  *hd.ExtendedKey
 }
 
-func NewZCashWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.Params, proxy proxy.Dialer, repoPath string) (*ZCashWallet, error) {
+func NewZCashWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.Params, proxy proxy.Dialer, cache cache.Cacher) (*ZCashWallet, error) {
 	seed := bip39.NewSeed(mnemonic, "")
 
 	mPrivKey, err := hd.NewMaster(seed, params)
@@ -58,7 +59,7 @@ func NewZCashWallet(cfg config.CoinConfig, mnemonic string, params *chaincfg.Par
 		return nil, err
 	}
 
-	wm, err := service.NewWalletService(cfg.DB, km, c, params, wi.Zcash, repoPath)
+	wm, err := service.NewWalletService(cfg.DB, km, c, params, wi.Zcash, cache)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `Cacher` interface is well defined. Cannot do things to the file contents without the source knowing about it. Allows the concerns of file persistence to remain within ob-go on startup.

This requires a Cacher to be created within ob-go. I recommend either a DB table or a flat file DB which accepts []bytes (like BoltDB) which is managed from within `schema/manager.go`