### PR TITLE
[#37] Fix dep to not prune C headers from secp256k1 lib

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,46 +3,61 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3d906247e6027a9bd6ff8e7954ccc4ae60d027568c9b5b5c809ac396083d3ece"
+  name = "github.com/OpenBazaar/go-ethwallet"
+  packages = [
+    "util",
+    "wallet"
+  ]
+  revision = "e7d827c16faae4b026f95de3c7a6438bce0dbd6e"
+
+[[projects]]
+  branch = "master"
   name = "github.com/OpenBazaar/golang-socketio"
   packages = [
     ".",
     "protocol",
-    "transport",
+    "transport"
   ]
-  pruneopts = "UT"
-  revision = "9fab7b0eb211a7134cea662b8de11496a41de94e"
+  revision = "909b73d947ae79609bc2c5b03cb480f35180c564"
 
 [[projects]]
   branch = "master"
-  digest = "1:1944ac2001e79cae5b06b762b252edcc489bc9a2bc98de29cc01f8af6082f16a"
   name = "github.com/OpenBazaar/spvwallet"
   packages = [
     ".",
-    "exchangerates",
+    "exchangerates"
   ]
-  pruneopts = "UT"
   revision = "91d1e8451c43b13686b912e3a7115f30870542f0"
 
 [[projects]]
   branch = "master"
-  digest = "1:ecb682dce5f6c5489d4db3268dc760a713db407965cbc84c22d5f7d8d9baf892"
   name = "github.com/OpenBazaar/wallet-interface"
   packages = ["."]
-  pruneopts = "UT"
-  revision = "7687012920442cab1f419d1665d7c1b6d52e255f"
+  revision = "90321224966c0c88e02e99f1f9d3cef18a77f399"
 
 [[projects]]
-  digest = "1:0f98f59e9a2f4070d66f0c9c39561f68fcd1dc837b22a852d28d0003aebd1b1e"
+  name = "github.com/allegro/bigcache"
+  packages = [
+    ".",
+    "queue"
+  ]
+  revision = "f31987a23e44c5121ef8c8b2f2ea2e8ffa37b068"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/aristanetworks/goarista"
+  packages = ["monotime"]
+  revision = "5faa74ffbed7096292069fdcd0eae96146a3158a"
+
+[[projects]]
   name = "github.com/boltdb/bolt"
   packages = ["."]
-  pruneopts = "UT"
   revision = "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8"
   version = "v1.3.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:6712e284f99d05038c9d4b46f0e6df140697e2ce96c19beac5fb10305cb878d3"
   name = "github.com/btcsuite/btcd"
   packages = [
     "addrmgr",
@@ -54,22 +69,18 @@
     "database",
     "peer",
     "txscript",
-    "wire",
+    "wire"
   ]
-  pruneopts = "UT"
-  revision = "67e573d211ace594f1366b4ce9d39726c4b19bd0"
+  revision = "3dcf298fed2d5fd65918dc560b3942b2aa0629e8"
 
 [[projects]]
   branch = "master"
-  digest = "1:30d4a548e09bca4a0c77317c58e7407e2a65c15325e944f9c08a7b7992f8a59e"
   name = "github.com/btcsuite/btclog"
   packages = ["."]
-  pruneopts = "UT"
   revision = "84c8d2346e9fc8c7b947e243b9c24e6df9fd206a"
 
 [[projects]]
   branch = "master"
-  digest = "1:43190b35675926c93f392feed190b2056efd1f4f1b247b559f2a63cc164fa104"
   name = "github.com/btcsuite/btcutil"
   packages = [
     ".",
@@ -78,90 +89,115 @@
     "bloom",
     "coinset",
     "hdkeychain",
-    "txsort",
+    "txsort"
   ]
-  pruneopts = "UT"
   revision = "ab6388e0c60ae4834a1f57511e20c17b5f78be4b"
 
 [[projects]]
   branch = "master"
-  digest = "1:69e5357e344f35f1d3da320bf85271b5d5d758a826a52f132a3da29d6112fcc2"
   name = "github.com/btcsuite/btcwallet"
   packages = [
     "internal/helpers",
     "wallet/internal/txsizes",
     "wallet/txauthor",
-    "wallet/txrules",
+    "wallet/txrules"
   ]
-  pruneopts = "UT"
-  revision = "69684e9091b3b1c3e2196ea88695594eca53a88a"
+  revision = "7ad4f1e81d7831b5b4bc8597fe9db731fbb3be22"
 
 [[projects]]
   branch = "master"
-  digest = "1:1e6b2f7aa98b082c30a1303c29a702c369b2ec6d86b74a599bc8bbe2333db299"
   name = "github.com/btcsuite/go-socks"
   packages = ["socks"]
-  pruneopts = "UT"
   revision = "4720035b7bfd2a9bb130b1c184f8bbe41b6f0d0f"
 
 [[projects]]
   branch = "master"
-  digest = "1:49ad1acb33bb5b40c0d197321d3cf9ee9a29eb02f4765ab7c316e08983eb7559"
   name = "github.com/btcsuite/golangcrypto"
   packages = ["ripemd160"]
-  pruneopts = "UT"
   revision = "53f62d9b43e87a6c56975cf862af7edf33a8d0df"
 
 [[projects]]
-  digest = "1:91fc3f4d1842584d1342364193106e80d1d532bbd1668fbd7c61627f01d0111f"
   name = "github.com/btcsuite/goleveldb"
   packages = [
     "leveldb/errors",
     "leveldb/storage",
-    "leveldb/util",
+    "leveldb/util"
   ]
-  pruneopts = "UT"
   revision = "3fd0373267b6461dbefe91cef614278064d05465"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:78097abc20f73ec968b3f67bf74deda55009caa4b801d0d04f36145c869ab3c3"
   name = "github.com/cevaris/ordered_map"
   packages = ["."]
-  pruneopts = "UT"
   revision = "0efaee1733e3399a3cb88fc7d2ce340bf2e863d7"
 
 [[projects]]
   branch = "master"
-  digest = "1:10b2525f2f30d4d1bf2fec0f6005e182aa11a90a5a8b3cf8bc2dd25bf34cac2b"
   name = "github.com/cpacia/BitcoinCash-Wallet"
   packages = [
     ".",
-    "exchangerates",
+    "exchangerates"
   ]
-  pruneopts = "UT"
   revision = "b636a21a73a04d908285d9959e33c69712cdb45b"
 
 [[projects]]
   branch = "master"
-  digest = "1:36236e7063db3314f32b60885ef7ddf8abab65cb055f3a21d118f7e19148cfa3"
   name = "github.com/cpacia/bchutil"
   packages = ["."]
-  pruneopts = "UT"
   revision = "b126f6a35b6c2968c0877cb4d2ac5dcf67682d27"
 
 [[projects]]
-  digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  pruneopts = "UT"
   revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
   version = "v1.1.1"
 
 [[projects]]
+  name = "github.com/deckarep/golang-set"
+  packages = ["."]
+  revision = "cbaa98ba5575e67703b32b4b19f73c91f3c4159e"
+  version = "v1.7.1"
+
+[[projects]]
+  name = "github.com/ethereum/go-ethereum"
+  packages = [
+    ".",
+    "accounts",
+    "accounts/abi",
+    "accounts/abi/bind",
+    "accounts/keystore",
+    "common",
+    "common/hexutil",
+    "common/math",
+    "common/mclock",
+    "common/prque",
+    "core/types",
+    "crypto",
+    "crypto/secp256k1",
+    "crypto/sha3",
+    "ethclient",
+    "ethdb",
+    "event",
+    "log",
+    "metrics",
+    "p2p/netutil",
+    "params",
+    "rlp",
+    "rpc",
+    "trie"
+  ]
+  revision = "dae82f098570e15d44584f0d7f350713f4774727"
+  version = "v1.8.19"
+
+[[projects]]
+  name = "github.com/go-stack/stack"
+  packages = ["."]
+  revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
+  version = "v1.8.0"
+
+[[projects]]
   branch = "master"
-  digest = "1:54e413c28b10c099d0b3410e9db627e3d892f35fd379f1dcaaef2e8ed11f0860"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -169,123 +205,173 @@
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp",
+    "ptypes/timestamp"
   ]
-  pruneopts = "UT"
-  revision = "75dceb112b174be156fa9952e66d3e99945572b4"
+  revision = "8d0c54c1246661d9a51ca0ba455d22116d485eaa"
 
 [[projects]]
   branch = "master"
-  digest = "1:fbf6ef64ade9cc8474adb1bc22d1679a3837c6f083666d6313bc0cadabc055f0"
+  name = "github.com/golang/snappy"
+  packages = ["."]
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
+
+[[projects]]
+  name = "github.com/google/uuid"
+  packages = ["."]
+  revision = "9b3b1e0f5f99ae461456d768e7d301a7acdaa2d8"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
   name = "github.com/gorilla/websocket"
   packages = ["."]
-  pruneopts = "UT"
   revision = "483fb8d7c32fcb4b5636cd293a92e3935932e2f4"
 
 [[projects]]
-  branch = "master"
-  digest = "1:4bb169ce06341a7c5e6c9a6734b25c606f59e2f765703301f92d159cf999672e"
-  name = "github.com/jessevdk/go-flags"
+  name = "github.com/hunterlong/tokenbalance"
   packages = ["."]
-  pruneopts = "UT"
-  revision = "5de817a9aa209ed35a164cb04aec82b7df1a47a6"
+  revision = "1fcaffaac40cf0559ccba1276d90757bdf1284e9"
+  version = "v1.72"
 
 [[projects]]
   branch = "master"
-  digest = "1:81e36f059f2dfe7a5c07d55cabf8a7f0183f22d75bb6daa9b2935855bdd7c6af"
+  name = "github.com/jessevdk/go-flags"
+  packages = ["."]
+  revision = "5de817a9aa209ed35a164cb04aec82b7df1a47a6"
+
+[[projects]]
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  revision = "5c8c8bd35d3832f5d134ae1e1e375b69a4d25242"
+  version = "v1.0.1"
+
+[[projects]]
+  branch = "master"
   name = "github.com/ltcsuite/ltcd"
   packages = [
     "chaincfg",
     "chaincfg/chainhash",
-    "wire",
+    "wire"
   ]
-  pruneopts = "UT"
   revision = "01737289d815e0e32c91e55593ba2fbd8d090b2c"
 
 [[projects]]
   branch = "master"
-  digest = "1:03cf305380cb294d7b458efa29d4f0557d454cffcb394cefccf990bf950dfcbc"
   name = "github.com/ltcsuite/ltcutil"
   packages = ["base58"]
-  pruneopts = "UT"
   revision = "a88d7dfb1c02af5dffe005ad21f40c42d9fd5ad0"
 
 [[projects]]
   branch = "master"
-  digest = "1:37e5b02c6e524dfcaccd66ee130572e6861da35ae70f734c1e8d7e1e71fa3db9"
   name = "github.com/ltcsuite/ltcwallet"
   packages = ["wallet/txrules"]
-  pruneopts = "UT"
   revision = "689fccd15fdf3c01cd35734ffe12409bc35a343b"
 
 [[projects]]
-  digest = "1:78bbb1ba5b7c3f2ed0ea1eab57bdd3859aec7e177811563edc41198a760b06af"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  pruneopts = "UT"
   revision = "ae18d6b8b3205b561c79e8e5f69bff09736185f4"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:41f3b549dbb8216e490c27926c09dc055aa509b3476e7cbc3317103990b13aeb"
   name = "github.com/op/go-logging"
   packages = ["."]
-  pruneopts = "UT"
   revision = "970db520ece77730c7e4724c61121037378659d9"
 
 [[projects]]
+  name = "github.com/pborman/uuid"
+  packages = ["."]
+  revision = "adf5a7427709b9deb95d29d3fa8a2bf9cfd388f1"
+  version = "v1.2"
+
+[[projects]]
+  name = "github.com/rjeczalik/notify"
+  packages = ["."]
+  revision = "69d839f37b13a8cb7a78366f7633a4071cb43be7"
+  version = "v0.9.2"
+
+[[projects]]
   branch = "master"
-  digest = "1:70d017cc9f1593814537c7b6071eb6d974d287638b9e9884a4eec5aa4b86c5d5"
   name = "github.com/roasbeef/btcd"
   packages = [
     "btcec",
     "chaincfg",
     "chaincfg/chainhash",
     "txscript",
-    "wire",
+    "wire"
   ]
-  pruneopts = "UT"
   revision = "a03db407e40d3b66ea29984263bbc8bf4d2f04c4"
 
 [[projects]]
   branch = "master"
-  digest = "1:a3780cd4884824a3a274c6c7f967c097cfebb0b8af9eddf1441e9f5d3f30e468"
   name = "github.com/roasbeef/btcutil"
   packages = [
     ".",
     "base58",
-    "bech32",
+    "bech32"
   ]
-  pruneopts = "UT"
   revision = "dfb640c57141f1c2113b92b4b16d2a89c30dd258"
 
 [[projects]]
+  name = "github.com/rs/cors"
+  packages = ["."]
+  revision = "9a47f48565a795472d43519dd49aac781f3034fb"
+  version = "v1.6.0"
+
+[[projects]]
+  name = "github.com/shopspring/decimal"
+  packages = ["."]
+  revision = "cd690d0c9e2447b1ef2a129a6b7b49077da89b8e"
+  version = "1.1.0"
+
+[[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "bcd833dfe83d3cebad139e4a29ed79cb2318bf95"
+  version = "v1.2.0"
+
+[[projects]]
   branch = "master"
-  digest = "1:6bae001f7c4cddc9ebf2b47bd5ff1bd3978a84b422c468d6037dad284c8c8e9d"
+  name = "github.com/syndtr/goleveldb"
+  packages = [
+    "leveldb",
+    "leveldb/cache",
+    "leveldb/comparer",
+    "leveldb/errors",
+    "leveldb/filter",
+    "leveldb/iterator",
+    "leveldb/journal",
+    "leveldb/memdb",
+    "leveldb/opt",
+    "leveldb/storage",
+    "leveldb/table",
+    "leveldb/util"
+  ]
+  revision = "b001fa50d6b27f3f0bb175a87d0cb55426d0a0ae"
+
+[[projects]]
+  branch = "master"
   name = "github.com/tyler-smith/go-bip39"
   packages = [
     ".",
-    "wordlists",
+    "wordlists"
   ]
-  pruneopts = "UT"
   revision = "dbb3b84ba2ef14e894f5e33d6c6e43641e665738"
 
 [[projects]]
   branch = "master"
-  digest = "1:734c27157144367f37acd13536569700f61f01576c4a5e9665ccb76f79966d97"
   name = "golang.org/x/crypto"
   packages = [
     "pbkdf2",
     "ripemd160",
     "scrypt",
+    "ssh/terminal"
   ]
-  pruneopts = "UT"
-  revision = "bfa7d42eb568d3c454e1853744768cc80718040d"
+  revision = "eb0de9b17e854e9b1ccd9963efafc79862359959"
 
 [[projects]]
   branch = "master"
-  digest = "1:43681672f6449f54f2d047ff16d353e5307dacd056ade60be49616d439476394"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -297,20 +383,20 @@
     "internal/timeseries",
     "proxy",
     "trace",
+    "websocket"
   ]
-  pruneopts = "UT"
-  revision = "10aee181995363b41f712a55844a0dd52ea04646"
+  revision = "adae6a3d119ae4890b46832a2e88a95adc62b8e7"
 
 [[projects]]
   branch = "master"
-  digest = "1:e2503f590982f6c0cc06abd7b94b17ded6804bada8eb79af753b5fb676dfdecc"
   name = "golang.org/x/sys"
-  packages = ["unix"]
-  pruneopts = "UT"
-  revision = "3a76605856fddce5718553cbb8bd50ca492a7274"
+  packages = [
+    "unix",
+    "windows"
+  ]
+  revision = "4ed8d59d0b35e1e29334a206d1b3f38b1e5dfb31"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -326,23 +412,19 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable",
+    "unicode/rangetable"
   ]
-  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:56b0bca90b7e5d1facf5fbdacba23e4e0ce069d25381b8e2f70ef1e7ebfb9c1a"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
-  pruneopts = "UT"
-  revision = "c830210a61dfaa790e1920f8d0470fc27bc2efbe"
+  revision = "31ac5d88444a9e7ad18077db9a165d793ad06a2e"
 
 [[projects]]
   branch = "master"
-  digest = "1:bf5997629ae98b3245b49d3297465e62b303a6126a7f328f770a7b82e1c50807"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -353,6 +435,7 @@
     "codes",
     "connectivity",
     "credentials",
+    "credentials/internal",
     "encoding",
     "encoding/proto",
     "grpclog",
@@ -362,6 +445,7 @@
     "internal/channelz",
     "internal/envconfig",
     "internal/grpcrand",
+    "internal/grpcsync",
     "internal/syscall",
     "internal/transport",
     "keepalive",
@@ -375,64 +459,31 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap",
+    "tap"
   ]
-  pruneopts = "UT"
-  revision = "d27440de3ff4bcac15a44957845d2b7c1042ad35"
+  revision = "f3eb5bc06e940f09d5ab876c749c489d43cfbf1d"
 
 [[projects]]
   branch = "v1"
-  digest = "1:e6a5421ece62f71bef4f9d957747f5837900caa2e5e343da6e124a1b88abbfd0"
   name = "gopkg.in/jarcoal/httpmock.v1"
   packages = ["."]
-  pruneopts = "UT"
-  revision = "c463961d8bfec5823f8100e620bcc73e9afdd7d4"
+  revision = "275e9df93516fc27a998eca24c8f1cca277ce5bf"
+
+[[projects]]
+  branch = "v2"
+  name = "gopkg.in/natefinch/npipe.v2"
+  packages = ["."]
+  revision = "c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6"
+
+[[projects]]
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/OpenBazaar/golang-socketio",
-    "github.com/OpenBazaar/golang-socketio/protocol",
-    "github.com/OpenBazaar/golang-socketio/transport",
-    "github.com/OpenBazaar/spvwallet",
-    "github.com/OpenBazaar/spvwallet/exchangerates",
-    "github.com/OpenBazaar/wallet-interface",
-    "github.com/btcsuite/btcd/blockchain",
-    "github.com/btcsuite/btcd/btcec",
-    "github.com/btcsuite/btcd/chaincfg",
-    "github.com/btcsuite/btcd/chaincfg/chainhash",
-    "github.com/btcsuite/btcd/txscript",
-    "github.com/btcsuite/btcd/wire",
-    "github.com/btcsuite/btcutil",
-    "github.com/btcsuite/btcutil/base58",
-    "github.com/btcsuite/btcutil/bech32",
-    "github.com/btcsuite/btcutil/coinset",
-    "github.com/btcsuite/btcutil/hdkeychain",
-    "github.com/btcsuite/btcutil/txsort",
-    "github.com/btcsuite/btcwallet/wallet/txauthor",
-    "github.com/btcsuite/btcwallet/wallet/txrules",
-    "github.com/btcsuite/golangcrypto/ripemd160",
-    "github.com/cpacia/BitcoinCash-Wallet",
-    "github.com/cpacia/BitcoinCash-Wallet/exchangerates",
-    "github.com/cpacia/bchutil",
-    "github.com/golang/protobuf/proto",
-    "github.com/golang/protobuf/ptypes/timestamp",
-    "github.com/gorilla/websocket",
-    "github.com/jessevdk/go-flags",
-    "github.com/ltcsuite/ltcd/chaincfg",
-    "github.com/ltcsuite/ltcd/chaincfg/chainhash",
-    "github.com/ltcsuite/ltcutil/base58",
-    "github.com/ltcsuite/ltcwallet/wallet/txrules",
-    "github.com/op/go-logging",
-    "github.com/roasbeef/btcutil",
-    "github.com/tyler-smith/go-bip39",
-    "golang.org/x/crypto/ripemd160",
-    "golang.org/x/net/context",
-    "golang.org/x/net/proxy",
-    "google.golang.org/grpc",
-    "google.golang.org/grpc/reflection",
-    "gopkg.in/jarcoal/httpmock.v1",
-  ]
+  inputs-digest = "504144b024d0aa8c39d6e134d539ce717e49ec65f143b813b81fe7c36ad282d6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -116,3 +116,11 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[override]]
+  name = "github.com/ethereum/go-ethereum"
+  version = "1.8.19"
+
+[[prune.project]]
+    name = "github.com/ethereum/go-ethereum"
+    unused-packages = false


### PR DESCRIPTION
Found a solution based on https://github.com/golang/dep/issues/1725#issuecomment-374293514 

This along with the `ethereum` override allows dep to build the vendor tree including the c headers:
```diff --git a/Gopkg.toml b/Gopkg.toml
index ee11806..ce1a3a1 100644
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -116,3 +116,11 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[override]]
+  name = "github.com/ethereum/go-ethereum"
+  version = "1.8.19"
+
+[[prune.project]]
+    name = "github.com/ethereum/go-ethereum"
+    unused-packages = false```