### PR TITLE
BUGFIX: Close socket down before closing channel.

### DIFF
--- a/client/blockbook/client.go
+++ b/client/blockbook/client.go
@@ -171,9 +171,9 @@ func (i *BlockBookClient) shutdownWebsocket() {
 	if i.SocketClient != nil {
 		i.socketMutex.Lock()
 		defer i.socketMutex.Unlock()
-		i.websocketWatchdog.putDown()
 		i.SocketClient.Close()
 		i.SocketClient = nil
+		i.websocketWatchdog.putDown()
 	}
 }
 


### PR DESCRIPTION
`bark` sends to a channel that is closed by `putDown`. `bark` is called on socket events. `putDown` must be called after the socket events are no longer handled. AFAICT `Close`ing the socket will stop all new events.