### PR TITLE
Filter addresses returned that start with ltc1

### DIFF
--- a/litecoin/wallet.go
+++ b/litecoin/wallet.go
@@ -150,13 +150,12 @@ func (w *LitecoinWallet) CurrentAddress(purpose wi.KeyPurpose) btcutil.Address {
 	for {
 		key, _ := w.km.GetCurrentKey(purpose)
 		addr, _ = litecoinAddress(key, w.params)
-		fmt.Println(addr)
 
 		if !strings.HasPrefix(strings.ToLower(addr.String()), "ltc1") {
 			break
 		}
 		if err := w.db.Keys().MarkKeyAsUsed(addr.ScriptAddress()); err != nil {
-			w.log.Error("Error marking key as used: %s", err)
+			w.log.Errorf("Error marking key as used: %s", err)
 		}
 	}
 	return btcutil.Address(addr)

--- a/litecoin/wallet.go
+++ b/litecoin/wallet.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/OpenBazaar/multiwallet/cache"
@@ -145,16 +146,35 @@ func (w *LitecoinWallet) ChildKey(keyBytes []byte, chaincode []byte, isPrivateKe
 }
 
 func (w *LitecoinWallet) CurrentAddress(purpose wi.KeyPurpose) btcutil.Address {
-	key, _ := w.km.GetCurrentKey(purpose)
-	addr, _ := litecoinAddress(key, w.params)
+	var addr btcutil.Address
+	for {
+		key, _ := w.km.GetCurrentKey(purpose)
+		addr, _ = litecoinAddress(key, w.params)
+		fmt.Println(addr)
+
+		if !strings.HasPrefix(strings.ToLower(addr.String()), "ltc1") {
+			break
+		}
+		if err := w.db.Keys().MarkKeyAsUsed(addr.ScriptAddress()); err != nil {
+			w.log.Error("Error marking key as used: %s", err)
+		}
+	}
 	return btcutil.Address(addr)
 }
 
 func (w *LitecoinWallet) NewAddress(purpose wi.KeyPurpose) btcutil.Address {
-	i, _ := w.db.Keys().GetUnused(purpose)
-	key, _ := w.km.GenerateChildKey(purpose, uint32(i[1]))
-	addr, _ := litecoinAddress(key, w.params)
-	w.db.Keys().MarkKeyAsUsed(addr.ScriptAddress())
+	var addr btcutil.Address
+	for {
+		i, _ := w.db.Keys().GetUnused(purpose)
+		key, _ := w.km.GenerateChildKey(purpose, uint32(i[1]))
+		addr, _ = litecoinAddress(key, w.params)
+		if err := w.db.Keys().MarkKeyAsUsed(addr.ScriptAddress()); err != nil {
+			w.log.Error("Error marking key as used: %s", err)
+		}
+		if !strings.HasPrefix(strings.ToLower(addr.String()), "ltc1") {
+			break
+		}
+	}
 	return btcutil.Address(addr)
 }
 

--- a/litecoin/wallet_test.go
+++ b/litecoin/wallet_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestLitecoinWallet_CurrentAddress(t *testing.T) {
-	w, err := createWallet()
+	w, seed, err := createWalletAndSeed()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -20,7 +20,7 @@ func TestLitecoinWallet_CurrentAddress(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		addr := w.CurrentAddress(wallet.EXTERNAL)
 		if strings.HasPrefix(strings.ToLower(addr.String()), "ltc1") {
-			t.Errorf("Address %s hash ltc1 prefix", addr)
+			t.Errorf("Address %s hash ltc1 prefix: seed %x", addr, seed)
 		}
 		if err := w.db.Keys().MarkKeyAsUsed(addr.ScriptAddress()); err != nil {
 			t.Fatal(err)
@@ -29,7 +29,7 @@ func TestLitecoinWallet_CurrentAddress(t *testing.T) {
 }
 
 func TestLitecoinWallet_NewAddress(t *testing.T) {
-	w, err := createWallet()
+	w, seed, err := createWalletAndSeed()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,35 +37,35 @@ func TestLitecoinWallet_NewAddress(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		addr := w.NewAddress(wallet.EXTERNAL)
 		if strings.HasPrefix(strings.ToLower(addr.String()), "ltc1") {
-			t.Errorf("Address %s hash ltc1 prefix", addr)
+			t.Errorf("Address %s hash ltc1 prefix: %x", addr, seed)
 		}
 	}
 }
 
-func createWallet() (*LitecoinWallet, error) {
+func createWalletAndSeed() (*LitecoinWallet, []byte, error) {
 	ds := datastore.NewMockMultiwalletDatastore()
 	db, err := ds.GetDatastoreForWallet(wallet.Litecoin)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	seed := make([]byte, 32)
 	if _, err := rand.Read(seed); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	masterPrivKey, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	km, err := keys.NewKeyManager(db.Keys(), &chaincfg.MainNetParams, masterPrivKey, wallet.Litecoin, litecoinAddress)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	return &LitecoinWallet{
 		db:     db,
 		km:     km,
 		params: &chaincfg.MainNetParams,
-	}, nil
+	}, seed, nil
 }

--- a/litecoin/wallet_test.go
+++ b/litecoin/wallet_test.go
@@ -1,0 +1,71 @@
+package litecoin
+
+import (
+	"crypto/rand"
+	"github.com/OpenBazaar/multiwallet/datastore"
+	"github.com/OpenBazaar/multiwallet/keys"
+	"github.com/OpenBazaar/wallet-interface"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil/hdkeychain"
+	"strings"
+	"testing"
+)
+
+func TestLitecoinWallet_CurrentAddress(t *testing.T) {
+	w, err := createWallet()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		addr := w.CurrentAddress(wallet.EXTERNAL)
+		if strings.HasPrefix(strings.ToLower(addr.String()), "ltc1") {
+			t.Errorf("Address %s hash ltc1 prefix", addr)
+		}
+		if err := w.db.Keys().MarkKeyAsUsed(addr.ScriptAddress()); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestLitecoinWallet_NewAddress(t *testing.T) {
+	w, err := createWallet()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		addr := w.NewAddress(wallet.EXTERNAL)
+		if strings.HasPrefix(strings.ToLower(addr.String()), "ltc1") {
+			t.Errorf("Address %s hash ltc1 prefix", addr)
+		}
+	}
+}
+
+func createWallet() (*LitecoinWallet, error) {
+	ds := datastore.NewMockMultiwalletDatastore()
+	db, err := ds.GetDatastoreForWallet(wallet.Litecoin)
+	if err != nil {
+		return nil, err
+	}
+
+	seed := make([]byte, 32)
+	if _, err := rand.Read(seed); err != nil {
+		return nil, err
+	}
+
+	masterPrivKey, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
+	if err != nil {
+		return nil, err
+	}
+	km, err := keys.NewKeyManager(db.Keys(), &chaincfg.MainNetParams, masterPrivKey, wallet.Litecoin, litecoinAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LitecoinWallet{
+		db:     db,
+		km:     km,
+		params: &chaincfg.MainNetParams,
+	}, nil
+}


### PR DESCRIPTION
Updates the litecoin get address functions to keep generating addresses until it gets one that does not start with ltc1. This is needed because the decode function interprets addresses starting with ltc1 as segwit addresses where these addresses are not. 

I tried writing a test for this but to mock this scenario requires about 10 minutes of brute forcing to get an address which does start with ltc1. Probably too long to run every time. 