### PR TITLE
Limit Max inflight queries to blockbook.

### DIFF
--- a/litecoin/address/address.go
+++ b/litecoin/address/address.go
@@ -160,26 +160,24 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 		prefix := addr[:oneIndex+1]
 		if IsBech32SegwitPrefix(prefix) {
 			witnessVer, witnessProg, err := decodeSegWitAddress(addr)
-			if err != nil {
-				return nil, err
-			}
+			if err == nil {
+				// We currently only support P2WPKH and P2WSH, which is
+				// witness version 0.
+				if witnessVer != 0 {
+					return nil, UnsupportedWitnessVerError(witnessVer)
+				}
 
-			// We currently only support P2WPKH and P2WSH, which is
-			// witness version 0.
-			if witnessVer != 0 {
-				return nil, UnsupportedWitnessVerError(witnessVer)
-			}
+				// The HRP is everything before the found '1'.
+				hrp := prefix[:len(prefix)-1]
 
-			// The HRP is everything before the found '1'.
-			hrp := prefix[:len(prefix)-1]
-
-			switch len(witnessProg) {
-			case 20:
-				return newAddressWitnessPubKeyHash(hrp, witnessProg)
-			case 32:
-				return newAddressWitnessScriptHash(hrp, witnessProg)
-			default:
-				return nil, UnsupportedWitnessProgLenError(len(witnessProg))
+				switch len(witnessProg) {
+				case 20:
+					return newAddressWitnessPubKeyHash(hrp, witnessProg)
+				case 32:
+					return newAddressWitnessScriptHash(hrp, witnessProg)
+				default:
+					return nil, UnsupportedWitnessProgLenError(len(witnessProg))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This aims to fix the following issues:
* Prevents more than 25 requests in-flight to Blockbook within each GetTransactions and GetUtxos call
* Allow LTC segwit prefixed addresses to attempt to be decoded as non-segwit addresses instead of assuming they cannot.