### PR TITLE
(#1899) Revert to original transports for API requests

### DIFF
--- a/bitcoincash/exchange_rates.go
+++ b/bitcoincash/exchange_rates.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/OpenBazaar/multiwallet/util"
 	"golang.org/x/net/proxy"
-	"net"
 	"net/http"
 	"reflect"
 	"sync"
@@ -36,12 +35,15 @@ func NewBitcoinCashPriceFetcher(dialer proxy.Dialer) *BitcoinCashPriceFetcher {
 	b := BitcoinCashPriceFetcher{
 		cache: make(map[string]float64),
 	}
-	dial := net.Dial
+	var client *http.Client
 	if dialer != nil {
-		dial = dialer.Dial
+		dial := dialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Minute}
+	} else {
+		client = &http.Client{Timeout: time.Minute}
 	}
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Minute}
+
 
 	b.providers = []*ExchangeRateProvider{
 		{"https://ticker.openbazaar.org/api", b.cache, client, OpenBazaarDecoder{}},

--- a/client/blockbook/client.go
+++ b/client/blockbook/client.go
@@ -122,16 +122,20 @@ func NewBlockBookClient(apiUrl string, proxyDialer proxy.Dialer) (*BlockBookClie
 		return nil, err
 	}
 
-	dial := net.Dial
+	var customClient http.Client
 	if proxyDialer != nil {
-		dial = proxyDialer.Dial
+		dial := proxyDialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		customClient = http.Client{Timeout: time.Second * 30, Transport: tbTransport}
+	} else {
+		customClient = http.Client{Timeout: time.Second * 30}
 	}
 
 	bch := make(chan model.Block)
 	tch := make(chan model.Transaction)
-	tbTransport := &http.Transport{Dial: dial}
+
 	ic := &BlockBookClient{
-		HTTPClient:      http.Client{Timeout: time.Second * 30, Transport: tbTransport},
+		HTTPClient:      customClient,
 		apiUrl:          u,
 		proxyDialer:     proxyDialer,
 		blockNotifyChan: bch,

--- a/client/blockbook/client.go
+++ b/client/blockbook/client.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"path"

--- a/litecoin/exchange_rates.go
+++ b/litecoin/exchange_rates.go
@@ -3,7 +3,6 @@ package litecoin
 import (
 	"encoding/json"
 	"errors"
-	"net"
 	"net/http"
 	"reflect"
 	"strconv"

--- a/litecoin/exchange_rates.go
+++ b/litecoin/exchange_rates.go
@@ -44,12 +44,15 @@ func NewLitecoinPriceFetcher(dialer proxy.Dialer) *LitecoinPriceFetcher {
 	z := LitecoinPriceFetcher{
 		cache: make(map[string]float64),
 	}
-	dial := net.Dial
+
+	var client *http.Client
 	if dialer != nil {
-		dial = dialer.Dial
+		dial := dialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Minute}
+	} else {
+		client = &http.Client{Timeout: time.Minute}
 	}
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Minute}
 
 	z.providers = []*ExchangeRateProvider{
 		{"https://ticker.openbazaar.org/api", z.cache, client, OpenBazaarDecoder{}, nil},

--- a/zcash/exchange_rates.go
+++ b/zcash/exchange_rates.go
@@ -44,12 +44,16 @@ func NewZcashPriceFetcher(dialer proxy.Dialer) *ZcashPriceFetcher {
 	z := ZcashPriceFetcher{
 		cache: make(map[string]float64),
 	}
-	dial := net.Dial
+
+	var client *http.Client
 	if dialer != nil {
-		dial = dialer.Dial
+		dial := dialer.Dial
+		tbTransport := &http.Transport{Dial: dial}
+		client = &http.Client{Transport: tbTransport, Timeout: time.Minute}
+	} else {
+		client = &http.Client{Timeout: time.Minute}
 	}
-	tbTransport := &http.Transport{Dial: dial}
-	client := &http.Client{Transport: tbTransport, Timeout: time.Minute}
+
 
 	z.providers = []*ExchangeRateProvider{
 		{"https://ticker.openbazaar.org/api", z.cache, client, OpenBazaarDecoder{}, nil},

--- a/zcash/exchange_rates.go
+++ b/zcash/exchange_rates.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/OpenBazaar/multiwallet/util"
-	"net"
 	"net/http"
 	"reflect"
 	"strconv"


### PR DESCRIPTION
Self-explanatory. It reverts custom transports for non-Tor nodes to original default transports.

Addresses the following issues:
- https://github.com/OpenBazaar/openbazaar-go/issues/1899
- https://github.com/OpenBazaar/openbazaar-go/issues/1861
- https://github.com/OpenBazaar/openbazaar-go/issues/1862

Related to:
- https://github.com/OpenBazaar/openbazaar-go/issues/1659
- https://github.com/OpenBazaar/openbazaar-go/issues/1363