### PR TITLE
Added unit tests for AddWatchedAddress

### DIFF
--- a/bitcoin/sign_test.go
+++ b/bitcoin/sign_test.go
@@ -70,6 +70,43 @@ func newMockWallet() (*BitcoinWallet, error) {
 	return bw, nil
 }
 
+func TestWalletService_VerifyWatchScriptFilter(t *testing.T) {
+	// Verify that AddWatchedAddress should never add a script which already represents a key from its own wallet
+	w, err := newMockWallet()
+	if err != nil {
+		t.Error(err)
+	}
+	keys := w.km.GetKeys()
+
+	addr, err := w.km.KeyToAddress(keys[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.AddWatchedAddress(addr)
+	if err == nil {
+		t.Error("Put watched scripts fails on key manager owned key")
+	}
+}
+
+func TestWalletService_VerifyWatchScriptPut(t *testing.T) {
+	// Verify that AddWatchedAddress should add a script which does not represent a key from its own wallet
+	w, err := newMockWallet()
+	if err != nil {
+		t.Error(err)
+	}
+
+	addr, err := w.DecodeAddress("16E4rWXEDcDRfmuMmJ6tTvL2uwHNgWF4yR")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = w.AddWatchedAddress(addr)
+	if err != nil {
+		t.Error("Put watched scripts fails on non-key manager owned key")
+	}
+}
+
 func waitForTxnSync(t *testing.T, txnStore wallet.Txns) {
 	// Look for a known txn, this sucks a bit. It would be better to check if the
 	// number of stored txns matched the expected, but not all the mock

--- a/bitcoincash/sign_test.go
+++ b/bitcoincash/sign_test.go
@@ -71,6 +71,43 @@ func newMockWallet() (*BitcoinCashWallet, error) {
 	return bw, nil
 }
 
+func TestWalletService_VerifyWatchScriptFilter(t *testing.T) {
+	// Verify that AddWatchedAddress should never add a script which already represents a key from its own wallet
+	w, err := newMockWallet()
+	if err != nil {
+		t.Error(err)
+	}
+	keys := w.km.GetKeys()
+
+	addr, err := w.km.KeyToAddress(keys[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.AddWatchedAddress(addr)
+	if err == nil {
+		t.Error("Put watched scripts fails on key manager owned key")
+	}
+}
+
+func TestWalletService_VerifyWatchScriptPut(t *testing.T) {
+	// Verify that AddWatchedAddress should add a script which does not represent a key from its own wallet
+	w, err := newMockWallet()
+	if err != nil {
+		t.Error(err)
+	}
+
+	addr, err := w.DecodeAddress("qqx0p0ja3xddkvwldaqwcvrkkgrzx6rjwuzla4ca90")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = w.AddWatchedAddress(addr)
+	if err != nil {
+		t.Error("Put watched scripts fails on non-key manager owned key")
+	}
+}
+
 func waitForTxnSync(t *testing.T, txnStore wallet.Txns) {
 	// Look for a known txn, this sucks a bit. It would be better to check if the
 	// number of stored txns matched the expected, but not all the mock

--- a/litecoin/sign_test.go
+++ b/litecoin/sign_test.go
@@ -69,6 +69,43 @@ func newMockWallet() (*LitecoinWallet, error) {
 	return bw, nil
 }
 
+func TestWalletService_VerifyWatchScriptFilter(t *testing.T) {
+	// Verify that AddWatchedAddress should never add a script which already represents a key from its own wallet
+	w, err := newMockWallet()
+	if err != nil {
+		t.Error(err)
+	}
+	keys := w.km.GetKeys()
+
+	addr, err := w.km.KeyToAddress(keys[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.AddWatchedAddress(addr)
+	if err == nil {
+		t.Error("Put watched scripts fails on key manager owned key")
+	}
+}
+
+func TestWalletService_VerifyWatchScriptPut(t *testing.T) {
+	// Verify that AddWatchedAddress should add a script which does not represent a key from its own wallet
+	w, err := newMockWallet()
+	if err != nil {
+		t.Error(err)
+	}
+
+	addr, err := w.DecodeAddress("LhyLNfBkoKshT7R8Pce6vkB9T2cP2o84hx")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = w.AddWatchedAddress(addr)
+	if err != nil {
+		t.Error("Put watched scripts fails on non-key manager owned key")
+	}
+}
+
 func waitForTxnSync(t *testing.T, txnStore wallet.Txns) {
 	// Look for a known txn, this sucks a bit. It would be better to check if the
 	// number of stored txns matched the expected, but not all the mock

--- a/zcash/sign_test.go
+++ b/zcash/sign_test.go
@@ -69,6 +69,43 @@ func newMockWallet() (*ZCashWallet, error) {
 	return bw, nil
 }
 
+func TestWalletService_VerifyWatchScriptFilter(t *testing.T) {
+	// Verify that AddWatchedAddress should never add a script which already represents a key from its own wallet
+	w, err := newMockWallet()
+	if err != nil {
+		t.Error(err)
+	}
+	keys := w.km.GetKeys()
+
+	addr, err := w.km.KeyToAddress(keys[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = w.AddWatchedAddress(addr)
+	if err == nil {
+		t.Error("Put watched scripts fails on key manager owned key")
+	}
+}
+
+func TestWalletService_VerifyWatchScriptPut(t *testing.T) {
+	// Verify that AddWatchedAddress should add a script which does not represent a key from its own wallet
+	w, err := newMockWallet()
+	if err != nil {
+		t.Error(err)
+	}
+
+	addr, err := w.DecodeAddress("t1aZvxRLCGVeMPFXvqfnBgHVEbi4c6g8MVa")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = w.AddWatchedAddress(addr)
+	if err != nil {
+		t.Error("Put watched scripts fails on non-key manager owned key")
+	}
+}
+
 func waitForTxnSync(t *testing.T, txnStore wallet.Txns) {
 	// Look for a known txn, this sucks a bit. It would be better to check if the
 	// number of stored txns matched the expected, but not all the mock


### PR DESCRIPTION
Added tests to verify that watch scripts are added properly. Also checks that watch scripts will not be added if the corresponding key exists in the wallet already. Finishes issue #107.