### PR TITLE
Update IsDust methods to return false if value is larger than max

### DIFF
--- a/bitcoin/wallet.go
+++ b/bitcoin/wallet.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -123,6 +124,9 @@ func (w *BitcoinWallet) CurrencyCode() string {
 }
 
 func (w *BitcoinWallet) IsDust(amount big.Int) bool {
+	if amount.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+		return false
+	}
 	return txrules.IsDustAmount(btc.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)
 }
 

--- a/bitcoin/wallet.go
+++ b/bitcoin/wallet.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -28,8 +27,8 @@ import (
 	btc "github.com/btcsuite/btcutil"
 	hd "github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
-	logging "github.com/op/go-logging"
-	bip39 "github.com/tyler-smith/go-bip39"
+	"github.com/op/go-logging"
+	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/net/proxy"
 )
 
@@ -124,7 +123,7 @@ func (w *BitcoinWallet) CurrencyCode() string {
 }
 
 func (w *BitcoinWallet) IsDust(amount big.Int) bool {
-	if amount.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+	if amount.IsInt64() {
 		return false
 	}
 	return txrules.IsDustAmount(btc.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)

--- a/bitcoin/wallet.go
+++ b/bitcoin/wallet.go
@@ -123,7 +123,7 @@ func (w *BitcoinWallet) CurrencyCode() string {
 }
 
 func (w *BitcoinWallet) IsDust(amount big.Int) bool {
-	if amount.IsInt64() {
+	if !amount.IsInt64() || amount.Cmp(big.NewInt(0)) <= 0 {
 		return false
 	}
 	return txrules.IsDustAmount(btc.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)

--- a/bitcoin/wallet_test.go
+++ b/bitcoin/wallet_test.go
@@ -1,0 +1,29 @@
+package bitcoin
+
+import (
+	"github.com/OpenBazaar/multiwallet/datastore"
+	"github.com/OpenBazaar/wallet-interface"
+	"math"
+	"math/big"
+	"testing"
+)
+
+func TestBitcoinWallet_IsDust(t *testing.T) {
+	ds := datastore.NewMockMultiwalletDatastore()
+	db, err := ds.GetDatastoreForWallet(wallet.Bitcoin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := BitcoinWallet{
+		db: db,
+	}
+
+	if !w.IsDust(*big.NewInt(0)) {
+		t.Error("Zero amount did not return dust")
+	}
+
+	if w.IsDust(*new(big.Int).SetUint64(math.MaxInt64 + 1)) {
+		t.Error("> max int64 returned false")
+	}
+}

--- a/bitcoin/wallet_test.go
+++ b/bitcoin/wallet_test.go
@@ -19,11 +19,15 @@ func TestBitcoinWallet_IsDust(t *testing.T) {
 		db: db,
 	}
 
-	if !w.IsDust(*big.NewInt(0)) {
-		t.Error("Zero amount did not return dust")
+	if w.IsDust(*big.NewInt(0)) {
+		t.Error("expected zero to be dust, but was not")
 	}
 
-	if w.IsDust(*new(big.Int).SetUint64(math.MaxInt64 + 1)) {
-		t.Error("> max int64 returned false")
+	overflowedInt := *new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	if overflowedInt.IsInt64() {
+		t.Error("expected big.Int to be overflowed, but wasn't")
+	}
+	if w.IsDust(overflowedInt) {
+		t.Error("expected overflowed big.Int to not be dust, but was")
 	}
 }

--- a/bitcoincash/wallet.go
+++ b/bitcoincash/wallet.go
@@ -126,7 +126,7 @@ func (w *BitcoinCashWallet) CurrencyCode() string {
 }
 
 func (w *BitcoinCashWallet) IsDust(amount big.Int) bool {
-	if amount.IsInt64() {
+	if !amount.IsInt64() || amount.Cmp(big.NewInt(0)) <= 0 {
 		return false
 	}
 	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)

--- a/bitcoincash/wallet.go
+++ b/bitcoincash/wallet.go
@@ -7,7 +7,6 @@ import (
 	"github.com/op/go-logging"
 	"io"
 	"log"
-	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -127,7 +126,7 @@ func (w *BitcoinCashWallet) CurrencyCode() string {
 }
 
 func (w *BitcoinCashWallet) IsDust(amount big.Int) bool {
-	if amount.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+	if amount.IsInt64() {
 		return false
 	}
 	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)

--- a/bitcoincash/wallet.go
+++ b/bitcoincash/wallet.go
@@ -7,6 +7,7 @@ import (
 	"github.com/op/go-logging"
 	"io"
 	"log"
+	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -126,6 +127,9 @@ func (w *BitcoinCashWallet) CurrencyCode() string {
 }
 
 func (w *BitcoinCashWallet) IsDust(amount big.Int) bool {
+	if amount.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+		return false
+	}
 	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)
 }
 

--- a/bitcoincash/wallet_test.go
+++ b/bitcoincash/wallet_test.go
@@ -1,0 +1,29 @@
+package bitcoincash
+
+import (
+	"github.com/OpenBazaar/multiwallet/datastore"
+	"github.com/OpenBazaar/wallet-interface"
+	"math"
+	"math/big"
+	"testing"
+)
+
+func TestBitcoinCashWallet_IsDust(t *testing.T) {
+	ds := datastore.NewMockMultiwalletDatastore()
+	db, err := ds.GetDatastoreForWallet(wallet.BitcoinCash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := BitcoinCashWallet{
+		db: db,
+	}
+
+	if !w.IsDust(*big.NewInt(0)) {
+		t.Error("Zero amount did not return dust")
+	}
+
+	if w.IsDust(*new(big.Int).SetUint64(math.MaxInt64 + 1)) {
+		t.Error("> max int64 returned false")
+	}
+}

--- a/bitcoincash/wallet_test.go
+++ b/bitcoincash/wallet_test.go
@@ -19,11 +19,15 @@ func TestBitcoinCashWallet_IsDust(t *testing.T) {
 		db: db,
 	}
 
-	if !w.IsDust(*big.NewInt(0)) {
-		t.Error("Zero amount did not return dust")
+	if w.IsDust(*big.NewInt(0)) {
+		t.Error("expected zero to be dust, but was not")
 	}
 
-	if w.IsDust(*new(big.Int).SetUint64(math.MaxInt64 + 1)) {
-		t.Error("> max int64 returned false")
+	overflowedInt := *new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	if overflowedInt.IsInt64() {
+		t.Error("expected big.Int to be overflowed, but wasn't")
+	}
+	if w.IsDust(overflowedInt) {
+		t.Error("expected overflowed big.Int to not be dust, but was")
 	}
 }

--- a/litecoin/wallet.go
+++ b/litecoin/wallet.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -27,7 +26,7 @@ import (
 	hd "github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/ltcsuite/ltcutil"
 	"github.com/ltcsuite/ltcwallet/wallet/txrules"
-	logging "github.com/op/go-logging"
+	"github.com/op/go-logging"
 	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/net/proxy"
 )
@@ -126,7 +125,7 @@ func (w *LitecoinWallet) CurrencyCode() string {
 }
 
 func (w *LitecoinWallet) IsDust(amount big.Int) bool {
-	if amount.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+	if amount.IsInt64() {
 		return false
 	}
 	return txrules.IsDustAmount(ltcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)

--- a/litecoin/wallet.go
+++ b/litecoin/wallet.go
@@ -125,7 +125,7 @@ func (w *LitecoinWallet) CurrencyCode() string {
 }
 
 func (w *LitecoinWallet) IsDust(amount big.Int) bool {
-	if amount.IsInt64() {
+	if !amount.IsInt64() || amount.Cmp(big.NewInt(0)) <= 0 {
 		return false
 	}
 	return txrules.IsDustAmount(ltcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)

--- a/litecoin/wallet.go
+++ b/litecoin/wallet.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"strconv"
 	"strings"
@@ -125,6 +126,9 @@ func (w *LitecoinWallet) CurrencyCode() string {
 }
 
 func (w *LitecoinWallet) IsDust(amount big.Int) bool {
+	if amount.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+		return false
+	}
 	return txrules.IsDustAmount(ltcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)
 }
 

--- a/litecoin/wallet_test.go
+++ b/litecoin/wallet_test.go
@@ -83,11 +83,15 @@ func TestLitecoinWallet_IsDust(t *testing.T) {
 		db: db,
 	}
 
-	if !w.IsDust(*big.NewInt(0)) {
-		t.Error("Zero amount did not return dust")
+	if w.IsDust(*big.NewInt(0)) {
+		t.Error("expected zero to be dust, but was not")
 	}
 
-	if w.IsDust(*new(big.Int).SetUint64(math.MaxInt64 + 1)) {
-		t.Error("> max int64 returned false")
+	overflowedInt := *new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	if overflowedInt.IsInt64() {
+		t.Error("expected big.Int to be overflowed, but wasn't")
+	}
+	if w.IsDust(overflowedInt) {
+		t.Error("expected overflowed big.Int to not be dust, but was")
 	}
 }

--- a/litecoin/wallet_test.go
+++ b/litecoin/wallet_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil/hdkeychain"
+	"math"
+	"math/big"
 	"strings"
 	"testing"
 )
@@ -68,4 +70,24 @@ func createWalletAndSeed() (*LitecoinWallet, []byte, error) {
 		km:     km,
 		params: &chaincfg.MainNetParams,
 	}, seed, nil
+}
+
+func TestLitecoinWallet_IsDust(t *testing.T) {
+	ds := datastore.NewMockMultiwalletDatastore()
+	db, err := ds.GetDatastoreForWallet(wallet.Litecoin)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := LitecoinWallet{
+		db: db,
+	}
+
+	if !w.IsDust(*big.NewInt(0)) {
+		t.Error("Zero amount did not return dust")
+	}
+
+	if w.IsDust(*new(big.Int).SetUint64(math.MaxInt64 + 1)) {
+		t.Error("> max int64 returned false")
+	}
 }

--- a/zcash/wallet.go
+++ b/zcash/wallet.go
@@ -125,7 +125,7 @@ func (w *ZCashWallet) CurrencyCode() string {
 }
 
 func (w *ZCashWallet) IsDust(amount big.Int) bool {
-	if amount.IsInt64() {
+	if !amount.IsInt64() || amount.Cmp(big.NewInt(0)) <= 0 {
 		return false
 	}
 	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)

--- a/zcash/wallet.go
+++ b/zcash/wallet.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -25,7 +24,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	hd "github.com/btcsuite/btcutil/hdkeychain"
 	"github.com/btcsuite/btcwallet/wallet/txrules"
-	logging "github.com/op/go-logging"
+	"github.com/op/go-logging"
 	"github.com/tyler-smith/go-bip39"
 	"golang.org/x/net/proxy"
 )
@@ -126,7 +125,7 @@ func (w *ZCashWallet) CurrencyCode() string {
 }
 
 func (w *ZCashWallet) IsDust(amount big.Int) bool {
-	if amount.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+	if amount.IsInt64() {
 		return false
 	}
 	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)

--- a/zcash/wallet.go
+++ b/zcash/wallet.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"strconv"
 	"time"
@@ -125,6 +126,9 @@ func (w *ZCashWallet) CurrencyCode() string {
 }
 
 func (w *ZCashWallet) IsDust(amount big.Int) bool {
+	if amount.Cmp(big.NewInt(math.MaxInt64)) >= 0 {
+		return false
+	}
 	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)
 }
 

--- a/zcash/wallet_test.go
+++ b/zcash/wallet_test.go
@@ -1,6 +1,8 @@
 package zcash
 
 import (
+	"math"
+	"math/big"
 	"testing"
 	"time"
 
@@ -92,5 +94,25 @@ func TestZCashWallet_Balance(t *testing.T) {
 	confirmed, unconfirmed = w.Balance()
 	if confirmed.Value.String() != "3000" || unconfirmed.Value.String() != "0" {
 		t.Error("Returned incorrect balance")
+	}
+}
+
+func TestZCashWallet_IsDust(t *testing.T) {
+	ds := datastore.NewMockMultiwalletDatastore()
+	db, err := ds.GetDatastoreForWallet(wallet.Zcash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := ZCashWallet{
+		db: db,
+	}
+
+	if !w.IsDust(*big.NewInt(0)) {
+		t.Error("Zero amount did not return dust")
+	}
+
+	if w.IsDust(*new(big.Int).SetUint64(math.MaxInt64 + 1)) {
+		t.Error("> max int64 returned false")
 	}
 }

--- a/zcash/wallet_test.go
+++ b/zcash/wallet_test.go
@@ -108,11 +108,15 @@ func TestZCashWallet_IsDust(t *testing.T) {
 		db: db,
 	}
 
-	if !w.IsDust(*big.NewInt(0)) {
-		t.Error("Zero amount did not return dust")
+	if w.IsDust(*big.NewInt(0)) {
+		t.Error("expected zero to be dust, but was not")
 	}
 
-	if w.IsDust(*new(big.Int).SetUint64(math.MaxInt64 + 1)) {
-		t.Error("> max int64 returned false")
+	overflowedInt := *new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	if overflowedInt.IsInt64() {
+		t.Error("expected big.Int to be overflowed, but wasn't")
+	}
+	if w.IsDust(overflowedInt) {
+		t.Error("expected overflowed big.Int to not be dust, but was")
 	}
 }


### PR DESCRIPTION
Return false from `IsDust` methods if value is larger than max int64. Otherwise it would wrap around. 

Fixes https://github.com/OpenBazaar/openbazaar-go/issues/1981