### PR TITLE
Protect spend amount overflow

### DIFF
--- a/bitcoin/sign.go
+++ b/bitcoin/sign.go
@@ -32,7 +32,7 @@ import (
 func (w *BitcoinWallet) buildTx(amount int64, addr btc.Address, feeLevel wi.FeeLevel, optionalOutput *wire.TxOut) (*wire.MsgTx, error) {
 	// Check for dust
 	script, _ := txscript.PayToAddrScript(addr)
-	if txrules.IsDustAmount(btc.Amount(amount), len(script), txrules.DefaultRelayFeePerKb) {
+	if isTxSizeDust(*big.NewInt(amount), len(script)) {
 		return nil, wi.ErrorDustAmount
 	}
 
@@ -158,7 +158,7 @@ func (w *BitcoinWallet) buildSpendAllTx(addr btc.Address, feeLevel wi.FeeLevel) 
 	fee := int64(estimatedSize) * feePerByte
 
 	// Check for dust output
-	if txrules.IsDustAmount(btc.Amount(totalIn-fee), len(script), txrules.DefaultRelayFeePerKb) {
+	if isTxSizeDust(*big.NewInt(totalIn - fee), len(script)) {
 		return nil, wi.ErrorDustAmount
 	}
 
@@ -230,8 +230,7 @@ func newUnsignedTransaction(outputs []*wire.TxOut, feePerKb btc.Amount, fetchInp
 		}
 		changeIndex := -1
 		changeAmount := inputAmount - targetAmount - maxRequiredFee
-		if changeAmount != 0 && !txrules.IsDustAmount(changeAmount,
-			P2PKHOutputSize, txrules.DefaultRelayFeePerKb) {
+		if changeAmount != 0 && !isTxSizeDust(*big.NewInt(int64(changeAmount)), P2PKHOutputSize) {
 			changeScript, err := fetchChange()
 			if err != nil {
 				return nil, err

--- a/bitcoin/wallet.go
+++ b/bitcoin/wallet.go
@@ -308,6 +308,9 @@ func (w *BitcoinWallet) Spend(amount big.Int, addr btc.Address, feeLevel wi.FeeL
 			return nil, err
 		}
 	} else {
+		if !amount.IsInt64() {
+			return nil, fmt.Errorf("amount (%s) is too large", amount.String())
+		}
 		tx, err = w.buildTx(amount.Int64(), addr, feeLevel, nil)
 		if err != nil {
 			return nil, err

--- a/bitcoin/wallet.go
+++ b/bitcoin/wallet.go
@@ -123,10 +123,14 @@ func (w *BitcoinWallet) CurrencyCode() string {
 }
 
 func (w *BitcoinWallet) IsDust(amount big.Int) bool {
+	return isTxSizeDust(amount, 25)
+}
+
+func isTxSizeDust(amount big.Int, size int) bool {
 	if !amount.IsInt64() || amount.Cmp(big.NewInt(0)) <= 0 {
 		return false
 	}
-	return txrules.IsDustAmount(btc.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)
+	return txrules.IsDustAmount(btc.Amount(amount.Int64()), size, txrules.DefaultRelayFeePerKb)
 }
 
 func (w *BitcoinWallet) MasterPrivateKey() *hd.ExtendedKey {

--- a/bitcoin/wallet_test.go
+++ b/bitcoin/wallet_test.go
@@ -1,11 +1,14 @@
 package bitcoin
 
 import (
-	"github.com/OpenBazaar/multiwallet/datastore"
-	"github.com/OpenBazaar/wallet-interface"
+	"fmt"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
+
+	"github.com/OpenBazaar/multiwallet/datastore"
+	"github.com/OpenBazaar/wallet-interface"
 )
 
 func TestBitcoinWallet_IsDust(t *testing.T) {
@@ -29,5 +32,26 @@ func TestBitcoinWallet_IsDust(t *testing.T) {
 	}
 	if w.IsDust(overflowedInt) {
 		t.Error("expected overflowed big.Int to not be dust, but was")
+	}
+}
+
+func TestBitcoinWallet_SpendFailsWhenTooLarge(t *testing.T) {
+	ds := datastore.NewMockMultiwalletDatastore()
+	db, err := ds.GetDatastoreForWallet(wallet.BitcoinCash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := BitcoinWallet{
+		db: db,
+	}
+
+	overflowedInt := new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	_, err = w.Spend(*overflowedInt, nil, wallet.ECONOMIC, "", false)
+	if err == nil {
+		t.Fatalf("expected overflowed amount to return an error, but did not")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("(%s) is too large", overflowedInt.String())) {
+		t.Errorf("expected error to contain (is too large), but was (%s)", err.Error())
 	}
 }

--- a/bitcoincash/wallet.go
+++ b/bitcoincash/wallet.go
@@ -126,10 +126,14 @@ func (w *BitcoinCashWallet) CurrencyCode() string {
 }
 
 func (w *BitcoinCashWallet) IsDust(amount big.Int) bool {
+	return isTxSizeDust(amount, 25)
+}
+
+func isTxSizeDust(amount big.Int, size int) bool {
 	if !amount.IsInt64() || amount.Cmp(big.NewInt(0)) <= 0 {
 		return false
 	}
-	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)
+	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), size, txrules.DefaultRelayFeePerKb)
 }
 
 func (w *BitcoinCashWallet) MasterPrivateKey() *hd.ExtendedKey {

--- a/bitcoincash/wallet.go
+++ b/bitcoincash/wallet.go
@@ -298,6 +298,9 @@ func (w *BitcoinCashWallet) Spend(amount big.Int, addr btcutil.Address, feeLevel
 			return nil, err
 		}
 	} else {
+		if !amount.IsInt64() {
+			return nil, fmt.Errorf("amount (%s) is too large", amount.String())
+		}
 		tx, err = w.buildTx(amount.Int64(), addr, feeLevel, nil)
 		if err != nil {
 			return nil, err

--- a/bitcoincash/wallet_test.go
+++ b/bitcoincash/wallet_test.go
@@ -1,11 +1,14 @@
 package bitcoincash
 
 import (
-	"github.com/OpenBazaar/multiwallet/datastore"
-	"github.com/OpenBazaar/wallet-interface"
+	"fmt"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
+
+	"github.com/OpenBazaar/multiwallet/datastore"
+	"github.com/OpenBazaar/wallet-interface"
 )
 
 func TestBitcoinCashWallet_IsDust(t *testing.T) {
@@ -29,5 +32,26 @@ func TestBitcoinCashWallet_IsDust(t *testing.T) {
 	}
 	if w.IsDust(overflowedInt) {
 		t.Error("expected overflowed big.Int to not be dust, but was")
+	}
+}
+
+func TestBitcoinCashWallet_SpendFailsWhenTooLarge(t *testing.T) {
+	ds := datastore.NewMockMultiwalletDatastore()
+	db, err := ds.GetDatastoreForWallet(wallet.BitcoinCash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := BitcoinCashWallet{
+		db: db,
+	}
+
+	overflowedInt := new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	_, err = w.Spend(*overflowedInt, nil, wallet.ECONOMIC, "", false)
+	if err == nil {
+		t.Fatalf("expected overflowed amount to return an error, but did not")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("(%s) is too large", overflowedInt.String())) {
+		t.Errorf("expected error to contain (is too large), but was (%s)", err.Error())
 	}
 }

--- a/litecoin/wallet.go
+++ b/litecoin/wallet.go
@@ -310,6 +310,9 @@ func (w *LitecoinWallet) Spend(amount big.Int, addr btcutil.Address, feeLevel wi
 			return nil, err
 		}
 	} else {
+		if !amount.IsInt64() {
+			return nil, fmt.Errorf("amount (%s) is too large", amount.String())
+		}
 		tx, err = w.buildTx(amount.Int64(), addr, feeLevel, nil)
 		if err != nil {
 			return nil, err

--- a/litecoin/wallet.go
+++ b/litecoin/wallet.go
@@ -125,10 +125,14 @@ func (w *LitecoinWallet) CurrencyCode() string {
 }
 
 func (w *LitecoinWallet) IsDust(amount big.Int) bool {
+	return isTxSizeDust(amount, 25)
+}
+
+func isTxSizeDust(amount big.Int, size int) bool {
 	if !amount.IsInt64() || amount.Cmp(big.NewInt(0)) <= 0 {
 		return false
 	}
-	return txrules.IsDustAmount(ltcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)
+	return txrules.IsDustAmount(ltcutil.Amount(amount.Int64()), size, txrules.DefaultRelayFeePerKb)
 }
 
 func (w *LitecoinWallet) MasterPrivateKey() *hd.ExtendedKey {

--- a/litecoin/wallet_test.go
+++ b/litecoin/wallet_test.go
@@ -2,15 +2,17 @@ package litecoin
 
 import (
 	"crypto/rand"
+	"fmt"
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+
 	"github.com/OpenBazaar/multiwallet/datastore"
 	"github.com/OpenBazaar/multiwallet/keys"
 	"github.com/OpenBazaar/wallet-interface"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil/hdkeychain"
-	"math"
-	"math/big"
-	"strings"
-	"testing"
 )
 
 func TestLitecoinWallet_CurrentAddress(t *testing.T) {
@@ -93,5 +95,26 @@ func TestLitecoinWallet_IsDust(t *testing.T) {
 	}
 	if w.IsDust(overflowedInt) {
 		t.Error("expected overflowed big.Int to not be dust, but was")
+	}
+}
+
+func TestLitecoinWallet_SpendFailsWhenTooLarge(t *testing.T) {
+	ds := datastore.NewMockMultiwalletDatastore()
+	db, err := ds.GetDatastoreForWallet(wallet.BitcoinCash)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := LitecoinWallet{
+		db: db,
+	}
+
+	overflowedInt := new(big.Int).Add(big.NewInt(math.MaxInt64), big.NewInt(1))
+	_, err = w.Spend(*overflowedInt, nil, wallet.ECONOMIC, "", false)
+	if err == nil {
+		t.Fatalf("expected overflowed amount to return an error, but did not")
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("(%s) is too large", overflowedInt.String())) {
+		t.Errorf("expected error to contain (is too large), but was (%s)", err.Error())
 	}
 }

--- a/zcash/sign.go
+++ b/zcash/sign.go
@@ -51,7 +51,7 @@ func (w *ZCashWallet) buildTx(amount int64, addr btc.Address, feeLevel wi.FeeLev
 	if err != nil {
 		return nil, err
 	}
-	if txrules.IsDustAmount(btc.Amount(amount), len(script), txrules.DefaultRelayFeePerKb) {
+	if isTxSizeDust(*big.NewInt(amount), len(script)) {
 		return nil, wi.ErrorDustAmount
 	}
 
@@ -192,7 +192,7 @@ func (w *ZCashWallet) buildSpendAllTx(addr btc.Address, feeLevel wi.FeeLevel) (*
 	fee := int64(estimatedSize) * feePerByte
 
 	// Check for dust output
-	if txrules.IsDustAmount(btc.Amount(totalIn-fee), len(script), txrules.DefaultRelayFeePerKb) {
+	if isTxSizeDust(*big.NewInt(totalIn - fee), len(script)) {
 		return nil, wi.ErrorDustAmount
 	}
 
@@ -272,8 +272,7 @@ func newUnsignedTransaction(outputs []*wire.TxOut, feePerKb btc.Amount, fetchInp
 		}
 		changeIndex := -1
 		changeAmount := inputAmount - targetAmount - maxRequiredFee
-		if changeAmount != 0 && !txrules.IsDustAmount(changeAmount,
-			P2PKHOutputSize, txrules.DefaultRelayFeePerKb) {
+		if changeAmount != 0 && !isTxSizeDust(*big.NewInt(int64(changeAmount)), P2PKHOutputSize) {
 			changeScript, err := fetchChange()
 			if err != nil {
 				return nil, err

--- a/zcash/wallet.go
+++ b/zcash/wallet.go
@@ -125,10 +125,14 @@ func (w *ZCashWallet) CurrencyCode() string {
 }
 
 func (w *ZCashWallet) IsDust(amount big.Int) bool {
+	return isTxSizeDust(amount, 25)
+}
+
+func isTxSizeDust(amount big.Int, size int) bool {
 	if !amount.IsInt64() || amount.Cmp(big.NewInt(0)) <= 0 {
 		return false
 	}
-	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), 25, txrules.DefaultRelayFeePerKb)
+	return txrules.IsDustAmount(btcutil.Amount(amount.Int64()), size, txrules.DefaultRelayFeePerKb)
 }
 
 func (w *ZCashWallet) MasterPrivateKey() *hd.ExtendedKey {

--- a/zcash/wallet.go
+++ b/zcash/wallet.go
@@ -310,6 +310,9 @@ func (w *ZCashWallet) Spend(amount big.Int, addr btcutil.Address, feeLevel wi.Fe
 			return nil, err
 		}
 	} else {
+		if !amount.IsInt64() {
+			return nil, fmt.Errorf("amount (%s) is too large", amount.String())
+		}
 		tx, err = w.buildTx(amount.Int64(), addr, feeLevel, nil)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR handles the overflow problems with the Spend behavior and shares the previously-added dust checking.

Fixes https://github.com/OpenBazaar/openbazaar-go/issues/1981